### PR TITLE
Update requirements

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,2 +1,2 @@
-django-debug-toolbar<1.8
+django-debug-toolbar
 -r requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ bleach==2.1.1
 certifi==2017.4.17
 chardet==3.0.4
 click==6.7
+dj-database-url==0.4.2
 django-debug-toolbar==1.7
 django-modelcluster==3.1
 django-settings-export==1.2.1
@@ -37,6 +38,6 @@ unittest-xml-reporting==2.1.0
 urllib3==1.21.1
 wagtail-factories==0.3.0
 wagtail-metadata==0.3.1
-wagtail==1.11.1
+wagtail==1.12
 webencodings==0.5.1
 willow==0.4

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,7 @@
 Django<1.12
 
 bleach
+dj-database-url
 django-modelcluster
 django-settings-export
 django-webpack-loader
@@ -8,7 +9,7 @@ factory_boy
 gunicorn
 pip-tools
 psycopg2
-wagtail
+wagtail==1.12
 wagtail-factories
 wagtail-metadata
 unittest-xml-reporting

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ bleach==2.1.1
 certifi==2017.4.17        # via requests
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
+dj-database-url==0.4.2
 django-modelcluster==3.1
 django-settings-export==1.2.1
 django-taggit==0.22.1     # via wagtail
@@ -35,6 +36,6 @@ unittest-xml-reporting==2.1.0
 urllib3==1.21.1           # via requests
 wagtail-factories==0.3.0
 wagtail-metadata==0.3.1
-wagtail==1.11.1
+wagtail==1.12
 webencodings==0.5.1       # via html5lib
 willow==0.4               # via wagtail


### PR DESCRIPTION
Upgrade Wagtail to lts
Adds dj-database-url as a requirement
Remove versioning from django-debug-toolbar (no longer needed with Wagtail 1.12)

Close #30 
Close #19 
Close #27